### PR TITLE
instaclone remote, for automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Once Instaclone is configured, run:
 - `instaclone install`: download configured items (and add to cache)
 - `instaclone configs`: sanity check configuration
 - `instaclone purge`: delete entire cache (published resources are never deleted)
-- `instaclone remote`: prints the current remote location to standard output
+- `instaclone remote`: prints the current remote location to standard output (good for sanity checking config or version string)
 
 Run `instaclone --help` for a complete list of flags and settings.
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Once Instaclone is configured, run:
 - `instaclone install`: download configured items (and add to cache)
 - `instaclone configs`: sanity check configuration
 - `instaclone purge`: delete entire cache (published resources are never deleted)
+- `instaclone remote`: prints the current remote location to standard output
 
 Run `instaclone --help` for a complete list of flags and settings.
 

--- a/instaclone/instaclone.py
+++ b/instaclone/instaclone.py
@@ -365,7 +365,7 @@ def version_for(config):
 #
 # ---- Command line ----
 
-Command = Enum("Command", "publish install purge configs")
+Command = Enum("Command", "publish install purge configs remote")
 _command_list = [c.name for c in Command]
 
 
@@ -407,6 +407,11 @@ def run_command(command, override_path=None, overrides=None, force=False, items=
     elif command == Command.install:
       for config in config_list:
         file_cache.install(config, version_for(config), force=force)
+
+    elif command == Command.remote:
+      for config in config_list:
+        loc = file_cache.remote_loc(config, version_for(config))
+        print(loc)
 
     else:
       raise AssertionError("unknown command: " + command)

--- a/instaclone/main.py
+++ b/instaclone/main.py
@@ -22,7 +22,7 @@ import argparse
 import sys
 
 NAME = "instaclone"
-VERSION = "0.3.1"
+VERSION = "0.3.2"
 DESCRIPTION = "instaclone: Fast, cached file installation"
 LONG_DESCRIPTION = __doc__
 


### PR DESCRIPTION
@jlevy This seems to do what I want: prints out the remote location based on the current config, for automation. Then I can use another tool to see if that location exists: `aws s3 ls` for example.

Or is there a better way?